### PR TITLE
Support for multiple worlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.edouardcourty</groupId>
     <artifactId>RealTimeSync</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/edouardcourty/realtimesync/RealTimeSync.java
+++ b/src/main/java/com/edouardcourty/realtimesync/RealTimeSync.java
@@ -1,8 +1,11 @@
 package com.edouardcourty.realtimesync;
 
+import com.edouardcourty.realtimesync.entity.WorldConfig;
 import com.edouardcourty.realtimesync.handler.ConfigFileHandler;
 import com.edouardcourty.realtimesync.handler.UpdateTimeHandler;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class RealTimeSync extends JavaPlugin {
     @Override
@@ -13,8 +16,20 @@ public class RealTimeSync extends JavaPlugin {
         ConfigFileHandler.init(this);
         ConfigFileHandler.handle();
 
-        UpdateTimeHandler.init(this);
-        UpdateTimeHandler.startLoop();
+        // Start handlers later, so all worlds had a chance to load first
+        final RealTimeSync instance = this;
+        BukkitRunnable runnable = new BukkitRunnable() {
+            @Override
+            public void run() {
+                ConfigurationSection worldSection = instance.getConfig().getConfigurationSection("worlds");
+                assert worldSection != null;
+                for(String worldName : worldSection.getKeys(false)) {
+                    WorldConfig config = new WorldConfig(worldName, worldSection.getInt(worldName + ".update_rate"), worldSection.getBoolean(worldName + ".force_daylightcycle_false"));
+                    (new UpdateTimeHandler(instance, config)).startLoop();
+                }
+            }
+        };
+        runnable.runTaskLater(this, 1L);
     }
 
     @Override

--- a/src/main/java/com/edouardcourty/realtimesync/entity/WorldConfig.java
+++ b/src/main/java/com/edouardcourty/realtimesync/entity/WorldConfig.java
@@ -1,0 +1,26 @@
+package com.edouardcourty.realtimesync.entity;
+
+public class WorldConfig {
+
+    protected String worldName;
+    protected int updateRate;
+    protected boolean forceDaylightcycleFalse;
+
+    public WorldConfig(String worldName, int updateRate, boolean forceDaylightcycleFalse) {
+        this.worldName = worldName;
+        this.updateRate = updateRate;
+        this.forceDaylightcycleFalse = forceDaylightcycleFalse;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public int getUpdateRate() {
+        return updateRate;
+    }
+
+    public boolean isForceDaylightcycleFalse() {
+        return forceDaylightcycleFalse;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,15 +4,14 @@
 # + ------------------------ +
 
 # World you want to change the time of
-world: world
-
-# Update rate (in game ticks, 20 ticks = 1 second)
-update_rate: 80
-
-# Forces the world to activate the doDayLightCycle gamerule that stops the time from changing by itself
-# The default state of this gamerule in a world is true. Settings this to true will set it to false.
-# Not enabling this can result in weird-looking sky at sunrise and sunset, since the sun will move before being updated.
-force_daylightcycle_false: true
+worlds:
+  world:
+    # Update rate (in game ticks, 20 ticks = 1 second)
+    update_rate: 80
+    # Forces the world to activate the doDayLightCycle gamerule that stops the time from changing by itself
+    # The default state of this gamerule in a world is true. Settings this to true will set it to false.
+    # Not enabling this can result in weird-looking sky at sunrise and sunset, since the sun will move before being updated.
+    force_daylightcycle_false: true
 
 # Will spam the console. Makes the plugin log every time the in-game time is changed.
 debug: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,3 +1,4 @@
 name: RealTimeSync
 main: com.edouardcourty.realtimesync.RealTimeSync
-version: 1.0.0
+version: 1.1.0
+api-version: 1.19


### PR DESCRIPTION
I've implemented support for multiple worlds as I needed that for a server I maintain. Maybe this would be interesting for somebody else.

This PR restructures the config a bit, so worlds can be added to a list, allowing for per-world config:
```yml
worlds:
  world:
    # ...
    update_rate: 80
    # ...
    force_daylightcycle_false: true
```
```yml
worlds:
  <worldName1>:
    ...
  <worldName2>:
    ...
```

Another thing I had to change is the UpdateTimeHandler. It can now be used as a regular object, so multiple instances can be created and run.
Because other worlds besides the "world" are being loaded at some point later in the startup process, the UpdateTimeHandler instances will not be started at plugin load, but instead when the server is done loading. This should ensure that all worlds are loaded and can be found by the plugin.
This version works fine on the before mentioned server (Paper 1.19), but I wasn't able to do extensive testing for other versions.

That said, I also updated the Paper dependency for 1.19 and added the `api-version` property to plugins.yml, but that should hardly even matter, as the plugin doesn't really use version-specific APIs.
